### PR TITLE
Revert "NRWL-631 update rack-ssl with parent fork changes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,7 @@ Force SSL/TLS in your app.
 2. Set `Strict-Transport-Security` header
 3. Flag all cookies as "secure"
 
-
-Installation
-------------
-
-    gem install rack-ssl
-
-
 Usage
 -----
 
-    require 'rack/ssl'
     use Rack::SSL

--- a/lib/rack/ssl.rb
+++ b/lib/rack/ssl.rb
@@ -46,15 +46,14 @@ module Rack
       end
 
       def redirect_to_https(env)
-        req = Request.new(env)
+        req        = Request.new(env)
+        url        = URI(req.url)
+        url.scheme = "https"
+        url.host   = @host if @host
+        headers    = hsts_headers.merge('Content-Type' => 'text/html',
+                                        'Location'     => url.to_s)
 
-        host = @host || req.host
-        location = "https://#{host}#{req.fullpath}"
-
-        status  = %w[GET HEAD].include?(req.request_method) ? 301 : 307
-        headers = { 'Content-Type' => 'text/html', 'Location' => location }
-
-        [status, headers, []]
+        [301, headers, []]
       end
 
       # http://tools.ietf.org/html/draft-hodges-strict-transport-sec-02

--- a/rack-ssl.gemspec
+++ b/rack-ssl.gemspec
@@ -1,11 +1,10 @@
 Gem::Specification.new do |s|
   s.name      = 'rack-ssl'
-  s.version   = '1.4.1'
-  s.date      = '2014-03-23'
+  s.version   = '1.3.2'
+  s.date      = '2011-03-24'
 
   s.homepage    = "https://github.com/josh/rack-ssl"
   s.summary     = "Force SSL/TLS in your app."
-  s.license     = "MIT"
   s.description = <<-EOS
     Rack middleware to force SSL/TLS.
   EOS

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -48,11 +48,6 @@ class TestSSL < Test::Unit::TestCase
       last_response.headers['Strict-Transport-Security']
   end
 
-  def test_no_hsts_with_insecure_connection
-    get "http://example.org/"
-    assert !last_response.headers['Strict-Transport-Security']
-  end
-
   def test_hsts_header
     self.app = Rack::SSL.new(default_app, :hsts => true)
     get "https://example.org/"
@@ -143,13 +138,6 @@ class TestSSL < Test::Unit::TestCase
       last_response.headers['Location']
   end
 
-  def test_redirect_to_host_port
-    self.app = Rack::SSL.new(default_app, :host => "ssl.example.org:443")
-    get "http://example.org/path?key=value"
-    assert_equal "https://ssl.example.org:443/path?key=value",
-      last_response.headers['Location']
-  end
-
   def test_redirect_to_secure_host_when_on_subdomain
     self.app = Rack::SSL.new(default_app, :host => "ssl.example.org")
     get "http://ssl.example.org/path?key=value"
@@ -162,40 +150,5 @@ class TestSSL < Test::Unit::TestCase
     get "http://double.rainbow.what.does.it.mean.example.co.uk/path?key=value"
     assert_equal "https://example.co.uk/path?key=value",
       last_response.headers['Location']
-  end
-
-  def test_status_get
-    get "http://example.org/"
-    assert_equal 301, last_response.status
-  end
-
-  def test_status_head
-    head "http://example.org/"
-    assert_equal 301, last_response.status
-  end
-
-  def test_status_options
-    options "http://example.org/"
-    assert_equal 307, last_response.status
-  end
-
-  def test_status_post
-    post "http://example.org/"
-    assert_equal 307, last_response.status
-  end
-
-  def test_status_put
-    put "http://example.org/"
-    assert_equal 307, last_response.status
-  end
-
-  def test_status_delete
-    delete "http://example.org/"
-    assert_equal 307, last_response.status
-  end
-
-  def test_status_patch
-    patch "http://example.org/"
-    assert_equal 307, last_response.status
   end
 end


### PR DESCRIPTION
railties is fixed at ~>1.3.2 and the security fix is in 1.3.4. I need to get at 1.3.4 instead of master. This reverts my merge of master into our fork.

Reverts Yesware/rack-ssl#2